### PR TITLE
Rename 'unpause' keywords to 'resume'

### DIFF
--- a/src/main/java/me/ledovec/tournament/GameProvider.java
+++ b/src/main/java/me/ledovec/tournament/GameProvider.java
@@ -3,7 +3,7 @@ package me.ledovec.tournament;
 import me.ledovec.tournament.events.GameFinishEvent;
 import me.ledovec.tournament.events.GamePauseEvent;
 import me.ledovec.tournament.events.GameStartEvent;
-import me.ledovec.tournament.events.GameUnpauseEvent;
+import me.ledovec.tournament.events.GameResumeEvent;
 import me.ledovec.tournament.listener.GameListener;
 import me.ledovec.tournament.session.GameSession;
 import org.bukkit.Bukkit;
@@ -33,9 +33,9 @@ public abstract non-sealed class GameProvider implements Game {
     }
 
     @Override
-    public void unpause() {
-        Bukkit.getPluginManager().callEvent(new GameUnpauseEvent(this));
-        this.onUnpause();
+    public void resume() {
+        Bukkit.getPluginManager().callEvent(new GameResumeEvent(this));
+        this.onResume();
     }
 
     @Override
@@ -66,6 +66,6 @@ public abstract non-sealed class GameProvider implements Game {
 
     public void onPause() { /* Method body is empty to be optional */ }
 
-    public void onUnpause() { /* Method body is empty to be optional */ }
+    public void onResume() { /* Method body is empty to be optional */ }
 
 }

--- a/src/main/java/me/ledovec/tournament/events/GameResumeEvent.java
+++ b/src/main/java/me/ledovec/tournament/events/GameResumeEvent.java
@@ -2,9 +2,9 @@ package me.ledovec.tournament.events;
 
 import me.ledovec.tournament.Game;
 
-public class GameUnpauseEvent extends GameEvent {
+public class GameResumeEvent extends GameEvent {
 
-    public GameUnpauseEvent(Game game) {
+    public GameResumeEvent(Game game) {
         super(game);
     }
 

--- a/src/main/java/me/ledovec/tournament/game/types/ParkourGame.java
+++ b/src/main/java/me/ledovec/tournament/game/types/ParkourGame.java
@@ -25,8 +25,8 @@ public class ParkourGame extends GameProvider {
     }
 
     @Override
-    public void onUnpause() {
-        super.onUnpause();
+    public void onResume() {
+        super.onResume();
     }
 
 }

--- a/src/main/java/me/ledovec/tournament/session/GameSession.java
+++ b/src/main/java/me/ledovec/tournament/session/GameSession.java
@@ -54,7 +54,7 @@ public class GameSession implements TimedSession<Long, Game>, Pauseable {
     }
 
     @Override
-    public void unpause() {
+    public void resume() {
         this.paused = false;
         pauseStop = Instant.now().getEpochSecond();
         pauseTime = pauseStop - pauseStart;

--- a/src/main/java/me/ledovec/tournament/session/Pauseable.java
+++ b/src/main/java/me/ledovec/tournament/session/Pauseable.java
@@ -4,6 +4,6 @@ public interface Pauseable {
 
     void pause();
 
-    void unpause();
+    void resume();
 
 }

--- a/src/main/java/me/ledovec/tournament/session/provider/GameSessionProvider.java
+++ b/src/main/java/me/ledovec/tournament/session/provider/GameSessionProvider.java
@@ -17,8 +17,8 @@ public class GameSessionProvider implements Provider<GameSession>, Pauseable {
     }
 
     @Override
-    public void unpause() {
-        gameSession.unpause();
+    public void resume() {
+        gameSession.resume();
     }
 
     @Override


### PR DESCRIPTION
Reason:
- Resume keyword better matches the purpose
- Does the word 'unpause' even exist?